### PR TITLE
ci(tests): add Windows CI and test harness; guard DRY_RUN; docs/policies

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -1,0 +1,27 @@
+# Agents Workspace
+
+This repository includes a local agents workspace under `.agent/` for AI assistants and automation tools. It centralizes prompts, context, configs, and workflows used when operating on this project.
+
+## Purpose
+- Keep agent context bundled with the codebase.
+- Provide clear, minimal config for tools and prompts.
+- Track project-specific notes and workflows under version control.
+
+## Structure
+- `.agent/README.md`: Overview and usage.
+- `.agent/config.yaml`: Minimal settings for this project.
+- `.agent/prompts/`: System and helper prompts.
+- `.agent/context/`: Notes, links, and scratch context.
+- `.agent/workflows/`: Task flows, SOPs, and playbooks.
+
+## Conventions
+- Store private tokens or secrets outside the repo; reference them via environment variables.
+- Keep prompts short and project‑specific; link to docs rather than duplicating large texts.
+- Prefer small, composable workflows over monolithic scripts.
+
+## Getting Started
+1) Review `.agent/README.md` and adjust `.agent/config.yaml` as needed.
+2) Add any project‑specific prompts to `.agent/prompts/`.
+3) Capture working notes in `.agent/context/notes.md`.
+4) Define repeatable procedures in `.agent/workflows/`.
+

--- a/.agent/README.md
+++ b/.agent/README.md
@@ -1,0 +1,21 @@
+# .agent Workspace
+
+Project-local workspace for AI agents and automation. Keep files short, token‑efficient, and machine‑readable. Longer, human‑readable specs live under `docs/`.
+
+Contents
+- `config.yaml`: Minimal agent config (portable path, limits).
+- `prompts/`: Concise system/assistant prompts for this repo.
+- `policies.json`: Compact operating rules for agents.
+- `goals.json`: Mission, objectives, constraints, metrics.
+- `backlog.json`: Technical TODOs/issues in JSON form.
+- `roadmap.json`: Milestone plan referencing backlog IDs.
+- `context/`: Links/short notes; avoid long texts.
+- `workflows/`: Small JSON runbooks/SOPs.
+
+Conventions
+- No secrets. Use env vars or external secret stores.
+- Prefer JSON for agent inputs; link to `docs/` for detail.
+- Keep single files < ~32KB to reduce token cost.
+
+See also
+- `docs/` for human‑readable specs, RPM, roadmap details.

--- a/.agent/backlog.json
+++ b/.agent/backlog.json
@@ -1,0 +1,106 @@
+{
+  "generated": "2025-09-02",
+  "todos": [
+    {
+      "id": "A-001",
+      "title": "Fix Windows 11 detection logic in :settingWindows",
+      "component": "Helpdesk-Tools.cmd",
+      "path": "Helpdesk-Tools.cmd",
+      "labels": ["bug", "compat"],
+      "priority": "p0",
+      "status": "open",
+      "acceptance": ["Detects Win10/11 via build or registry", "No false positives on Win10"]
+    },
+    {
+      "id": "A-002",
+      "title": "Consolidate duplicate helpers (winget/choco/installUnikey/addScheduleUpgrade/clean)",
+      "component": "core-helpers",
+      "path": "Helpdesk-Tools.cmd",
+      "labels": ["refactor"],
+      "priority": "p0",
+      "status": "open",
+      "acceptance": ["Single definition per helper", "All call sites updated", "No behavior change"]
+    },
+    {
+      "id": "A-003",
+      "title": "Replace hard-coded OfficeTool/ODT download with pinned source + checksum",
+      "component": "office",
+      "path": "Helpdesk-Tools.cmd",
+      "labels": ["security", "stability"],
+      "priority": "p0",
+      "status": "open",
+      "acceptance": ["Pinned version", "Checksum validated or signed source"]
+    },
+    {
+      "id": "A-004",
+      "title": "Implement Active Licenses actions (check/backup/restore/online/phone)",
+      "component": "licenses",
+      "path": "Helpdesk-Tools.cmd",
+      "labels": ["feature"],
+      "priority": "p1",
+      "status": "open",
+      "acceptance": ["No 'hold' calls in menu", "Clear user guidance"]
+    },
+    {
+      "id": "A-005",
+      "title": "Implement AIO System-Network/Helpdesk flows or hide until ready",
+      "component": "AIO",
+      "path": "Helpdesk-Tools.cmd",
+      "labels": ["feature", "ux"],
+      "priority": "p1",
+      "status": "open",
+      "acceptance": ["No dead-end placeholders", "Consistent messaging"]
+    },
+    {
+      "id": "A-006",
+      "title": "Harden Support Assistant installs (remove --ignore-checksums, verify source)",
+      "component": "utilities",
+      "path": "Helpdesk-Tools.cmd",
+      "labels": ["security"],
+      "priority": "p1",
+      "status": "open",
+      "acceptance": ["Installs succeed without ignoring checksums"]
+    },
+    {
+      "id": "A-007",
+      "title": "Guard createShortcut with if exist checks",
+      "component": "utilities",
+      "path": "Helpdesk-Tools.cmd",
+      "labels": ["bug"],
+      "priority": "p2",
+      "status": "open",
+      "acceptance": ["No errors when targets are missing"]
+    },
+    {
+      "id": "A-008",
+      "title": "Fix run-in-sandbox mapped folder copy and launcher",
+      "component": "sandbox",
+      "path": "scripts/run-in-sandbox.cmd",
+      "labels": ["bug", "ux"],
+      "priority": "p1",
+      "status": "open",
+      "acceptance": ["CMD files reliably appear on sandbox desktop and launch"]
+    },
+    {
+      "id": "A-009",
+      "title": "Refactor refactor.cmd to implement basic actions for menus",
+      "component": "refactor",
+      "path": "refactor.cmd",
+      "labels": ["feature", "refactor"],
+      "priority": "p2",
+      "status": "open",
+      "acceptance": ["Menu items 1–3 functional without placeholders"]
+    },
+    {
+      "id": "A-010",
+      "title": "Add fallback/no-network handling for GitHub API in packageManagement/checkCompatibility",
+      "component": "packageManagement",
+      "path": "Helpdesk-Tools.cmd",
+      "labels": ["stability"],
+      "priority": "p2",
+      "status": "open",
+      "acceptance": ["Graceful behavior without network", "Skips or uses cached versions"]
+    }
+  ]
+}
+

--- a/.agent/config.yaml
+++ b/.agent/config.yaml
@@ -1,0 +1,14 @@
+project:
+  name: cmdToolForHelpdesk
+  repo_path: "."  # make portable
+
+workspace:
+  agent_dir: ".agent"
+  context_dir: ".agent/context"
+  prompts_dir: ".agent/prompts"
+  workflows_dir: ".agent/workflows"
+
+conventions:
+  allow_secrets_in_repo: false
+  default_editor: "code"
+  max_agent_file_bytes: 32768  # keep agent-facing files compact

--- a/.agent/context/index.json
+++ b/.agent/context/index.json
@@ -1,0 +1,20 @@
+{
+  "key_files": [
+    {"path": "Helpdesk-Tools.cmd", "notes": "Main menu, installers, utilities"},
+    {"path": "refactor.cmd", "notes": "Refactor playground; many placeholders"},
+    {"path": "scripts/run-in-sandbox.cmd", "notes": "Windows Sandbox runner"},
+    {"path": "packages/windows_debloat.cmd", "notes": "Debloat routines"}
+  ],
+  "known_gaps": [
+    "Placeholders calling :hold() in several menus",
+    "Windows 11 detection logic using WMIC name parsing",
+    "Duplicate helper functions defined multiple times",
+    "Unpinned/unchecked external downloads"
+  ],
+  "docs": [
+    {"path": "docs/spec-cmdtool.md", "desc": "Human-readable technical spec"},
+    {"path": "docs/roadmap.md", "desc": "Narrative roadmap"},
+    {"path": "docs/rpm.md", "desc": "Roles, Process, Metrics"}
+  ]
+}
+

--- a/.agent/context/notes.md
+++ b/.agent/context/notes.md
@@ -1,0 +1,5 @@
+# Working Notes
+
+- Use this file for quick notes, links, or findings while working on the project.
+- Keep it lightweight; move persistent docs to the main README or docs when stable.
+

--- a/.agent/decision_policy.json
+++ b/.agent/decision_policy.json
@@ -1,0 +1,24 @@
+{
+  "language": {
+    "default": ["batch"],
+    "preferred_for_complex_logic": "powershell",
+    "rationale": "Batch is ubiquitous for menus/launchers; PowerShell handles complex flows."
+  },
+  "mvp": {
+    "use_when": ["end-to-end slice is possible", "uncertain scope"],
+    "exit": ["happy path complete", "rollback documented", "basic logs present"]
+  },
+  "hardening": {
+    "triggers": ["increased usage", "security finding", "perf constraints"],
+    "checklists": ["security_baseline", "observability", "resilience", "release_engineering"],
+    "templates": "/Users/tamld/Documents/MCP-Server/memory/templates/decision_framework.json"
+  },
+  "prioritization": {
+    "method": "RICE",
+    "anti_patterns": ["feature_chasing", "premature_optimization", "unbounded_refactors"]
+  },
+  "advice_policy": {
+    "defaults": ["suggest simplest viable 1–2 options", "state trade-offs", "ask for constraints if missing"]
+  }
+}
+

--- a/.agent/goals.json
+++ b/.agent/goals.json
@@ -1,0 +1,27 @@
+{
+  "project": "cmdToolForHelpdesk",
+  "mission": "Automate Windows helpdesk tasks: install, fix, optimize, and manage packages safely and repeatably.",
+  "objectives": [
+    "Stabilize core menus and remove placeholder holds",
+    "Unify duplicate install helpers for winget/choco",
+    "Harden downloads with version pinning and checksums",
+    "Improve Windows version detection (10/11) logic",
+    "Provide sandbox/test flows and clear rollback"
+  ],
+  "constraints": [
+    "Run on Windows 10 19041+ and Windows 11",
+    "No secrets in repo",
+    "Token-efficient agent files (<32KB each)"
+  ],
+  "success_metrics": [
+    ">90% functions non-placeholder",
+    "Zero critical failures in install/update paths",
+    "Winget/Choco checks pass and self-heal",
+    "Reduced code duplication in core helpers"
+  ],
+  "out_of_scope": [
+    "Adding unrelated tools not used by helpdesk",
+    "OS images or proprietary binaries storage"
+  ]
+}
+

--- a/.agent/policies.json
+++ b/.agent/policies.json
@@ -1,0 +1,89 @@
+{
+  "version": "1.0",
+  "non_overridable": {
+    "reflection_law": {
+      "id": "LAW-REFLECT-001",
+      "description": "Before significant actions or recommendations, the agent must reflect: 'Am I going beyond necessary information or current context (including MCP memory)? Is there any conflict with the current task?' If yes, the agent MUST confirm with the user before proceeding.",
+      "priority": "highest",
+      "override": "forbidden"
+    }
+  },
+  "scope": {
+    "allowed": [
+      "Edit repo files within cmdToolForHelpdesk",
+      "Add/update .agent JSON/YAML prompts, configs, workflows",
+      "Add human-readable specs under docs/",
+      "Refactor scripts minimally without breaking existing flows"
+    ],
+    "disallowed": [
+      "Storing secrets/keys in repo",
+      "Making destructive changes without backups",
+      "Network calls that violate licensing or TOU"
+    ]
+  },
+  "coding": {
+    "style": "Keep changes small, focused, and consistent with existing batch/shell style.",
+    "duplication": "Consolidate duplicate functions; do not introduce new duplicates.",
+    "compat": "Preserve Windows 10/11 support; guard features by version checks.",
+    "downloads": "Pin versions and verify checksums when feasible.",
+    "safety": "Fail fast with clear messages; add prompts for destructive ops.",
+    "comments": "Use English comments; prefer :: over REM in batch.",
+    "labels": "Batch labels lowerCamelCase; verbs first; menu labels end with 'Menu'; avoid hyphens.",
+    "variables": "Env vars UPPER_CASE; local vars descriptive lower_snake_case.",
+    "reference": "docs/coding-standards.md"
+  },
+  "validation": {
+    "phase": [
+      "Sanity-check syntax",
+      "Run most-specific test first",
+      "Then broader validations",
+      "Document manual steps if automation is not possible"
+    ]
+  },
+  "planning": {
+    "backlog_source": ".agent/backlog.json",
+    "roadmap_source": ".agent/roadmap.json",
+    "priority_order": [
+      "p0",
+      "p1",
+      "p2"
+    ]
+  },
+  "security": {
+    "privilege": "Elevate only when required. Explain why.",
+    "downloads": "Prefer official sources. Avoid --ignore-checksums unless justified.",
+    "logging": "Avoid printing sensitive data (e.g., credentials)."
+  },
+  "docs": {
+    "long_form": "Place human-readable technical detail in docs/",
+    "agent_form": "Keep .agent files concise and machine-readable"
+  },
+  "assets": {
+    "images_dir": "pictures",
+    "docs_dir": "docs"
+  },
+  "roles_source": "/Users/tamld/Documents/MCP-Server/memory/core/roles.json",
+  "role_selection": {
+    "coaching": "Use when editing MCP memory or before selecting a repo",
+    "engineering": "Use when working inside a repo with .agent present"
+  },
+  "reflection": {
+    "policy": "/Users/tamld/Documents/MCP-Server/memory/core/reflection/policy.json",
+    "cref": "/Users/tamld/Documents/MCP-Server/memory/core/reflection/cref.json",
+    "required_fields_l3_l4": [
+      "scope",
+      "belief_core",
+      "decay_factor",
+      "review_at_epoch",
+      "derived_from",
+      "variant_of"
+    ]
+  },
+  "vcs": {
+    "large_changes": "Open PR for review before merging.",
+    "small_changes": "Commit directly for low-risk tweaks (docs/minor fixes).",
+    "major_issues": "Open Issue for major bugs/refactors or release planning.",
+    "versioning": "Use SemVer for big updates; include date in script header.",
+    "contributing": "CONTRIBUTING.md"
+  }
+}

--- a/.agent/prompts/system.txt
+++ b/.agent/prompts/system.txt
@@ -1,0 +1,13 @@
+You are an engineering agent working on cmdToolForHelpdesk.
+Follow .agent/policies.json and keep changes minimal, scoped, and safe.
+Default tone: concise, direct, helpful. Prefer actionable steps.
+Prioritize tasks in .agent/backlog.json and milestones in .agent/roadmap.json.
+If details are needed, reference human-readable docs under docs/.
+Never store secrets. Pin versions and verify downloads when possible.
+Prefer JSON/YAML for agent artifacts; keep files compact (<32KB).
+
+Non-overridable law (highest priority): Before significant actions or recommendations, reflect: "Am I going beyond necessary information or current context (including MCP memory)? Is there any conflict with the current task?" If yes, pause and ask the user to confirm before proceeding. This rule cannot be replaced or overridden.
+
+Role behavior: If acting from MCP memory (coaching), be direct, assertive, and strategic (PM/DevOps/Eng lead). If acting in a project repo (engineering), be concise, practical, and assertive on quality. In both roles, refuse band‑aid fixes and prefer root‑cause solutions.
+
+Reflection fields (L3/L4): Include scope, belief_core, decay_factor, review_at_epoch, and lineage (derived_from/variant_of). Evaluate conflicts per scope; guard belief_core with human approval for overrides.

--- a/.agent/roadmap.json
+++ b/.agent/roadmap.json
@@ -1,0 +1,23 @@
+{
+  "milestones": [
+    {
+      "id": "M-0.7.0",
+      "name": "Stabilize core & security hardening",
+      "targets": ["A-001", "A-002", "A-003", "A-006", "A-010"],
+      "eta": "2025-09-15"
+    },
+    {
+      "id": "M-0.8.0",
+      "name": "Feature completeness in Licenses & AIO",
+      "targets": ["A-004", "A-005", "A-007", "A-008"],
+      "eta": "2025-09-30"
+    },
+    {
+      "id": "M-0.9.0",
+      "name": "Refactor menu & developer ergonomics",
+      "targets": ["A-009"],
+      "eta": "2025-10-15"
+    }
+  ]
+}
+

--- a/.agent/rules/guardrails.json
+++ b/.agent/rules/guardrails.json
@@ -1,0 +1,9 @@
+{
+  "non_overridable_laws": [
+    {
+      "id": "LAW-REFLECT-001",
+      "text": "Before significant actions or recommendations, ask: 'Am I going beyond necessary information or current context (including MCP memory)? Is there any conflict with the current task?' If yes, confirm with the user before proceeding.",
+      "priority": "highest"
+    }
+  ]
+}

--- a/.agent/state/checklist.json
+++ b/.agent/state/checklist.json
@@ -1,0 +1,10 @@
+{
+  "session": "default",
+  "items": [
+    {"id": "A-001", "task": "Fix Win11 detection logic", "status": "todo"},
+    {"id": "A-002", "task": "Consolidate duplicate helpers", "status": "todo"},
+    {"id": "A-003", "task": "Pin+checksum Office/OTP/ODT downloads", "status": "todo"}
+  ],
+  "updated_at": "2025-09-02T12:40:00Z"
+}
+

--- a/.agent/state/progress.json
+++ b/.agent/state/progress.json
@@ -1,0 +1,6 @@
+{
+  "completed": [],
+  "notes": [],
+  "updated_at": "2025-09-02T12:40:00Z"
+}
+

--- a/.agent/state/reflection_checklist.json
+++ b/.agent/state/reflection_checklist.json
@@ -1,0 +1,8 @@
+{
+  "law": "LAW-REFLECT-001",
+  "questions": [
+    "Am I going beyond necessary information or current context (incl. MCP memory)?",
+    "Is there any conflict with the current task or user request?"
+  ],
+  "action_if_yes": "Pause and ask the user to confirm before proceeding."
+}

--- a/.agent/workflows/README.md
+++ b/.agent/workflows/README.md
@@ -1,0 +1,10 @@
+# Workflows
+
+Add small, repeatable procedures here (checklists, task flows, SOPs). Keep each workflow focused and reference scripts or docs as needed.
+
+Example template
+1. Goal
+2. Inputs
+3. Steps
+4. Outputs
+

--- a/.agent/workflows/engineering.json
+++ b/.agent/workflows/engineering.json
@@ -1,0 +1,28 @@
+{
+  "name": "engineering_flow",
+  "phases": [
+    "discovery",
+    "scoping",
+    "reflection_gate",
+    "spike_optional",
+    "build",
+    "validate",
+    "harden",
+    "release",
+    "learn"
+  ],
+  "gates": {
+    "reflection_gate": {
+      "law": "LAW-REFLECT-001",
+      "question": "Am I going beyond necessary information/context or conflicting with the current task?",
+      "action_if_yes": "pause_and_confirm_with_user"
+    }
+  },
+  "gateways": {
+    "to_mvp": ["core flow understood"],
+    "to_hardening": ["usage/risk triggers"],
+    "to_release": ["acceptance criteria met"]
+  },
+  "checklists_templates": "/Users/tamld/Documents/MCP-Server/memory/templates/decision_framework.json",
+  "readiness": "/Users/tamld/Documents/MCP-Server/memory/templates/product_readiness_checklist.md"
+}

--- a/.agent/workflows/feature_intake.json
+++ b/.agent/workflows/feature_intake.json
@@ -1,0 +1,12 @@
+{
+  "name": "feature_intake",
+  "steps": [
+    "clarify problem and user",
+    "define acceptance criteria",
+    "estimate RICE score",
+    "decide MVP vs hardening",
+    "create backlog items and ADR if needed"
+  ],
+  "prioritization": "/Users/tamld/Documents/MCP-Server/memory/templates/prioritization.md"
+}
+

--- a/.agent/workflows/reflection.json
+++ b/.agent/workflows/reflection.json
@@ -1,0 +1,32 @@
+{
+  "name": "reflection_flow",
+  "levels": [
+    1,
+    2,
+    3,
+    4
+  ],
+  "core_policy": "/Users/tamld/Documents/MCP-Server/memory/core/reflection/policy.json",
+  "cref": "/Users/tamld/Documents/MCP-Server/memory/core/reflection/cref.json",
+  "project_trace": "/Users/tamld/Documents/MCP-Server/memory/projects/cmdToolForHelpdesk/reflection/trace.jsonl",
+  "project_anchors": "/Users/tamld/Documents/MCP-Server/memory/projects/cmdToolForHelpdesk/reflection/anchors.json",
+  "required_fields_l3_l4": [
+    "scope",
+    "belief_core",
+    "decay_factor",
+    "review_at_epoch",
+    "lineage"
+  ],
+  "notes": "Write Level-1 per step; Level-2 on deviation; Level-3 only with high confidence and alignment; Level-4 requires explicit approval. Compute S_core and S_adaptive; resolve per decision_rules; log conflicts.",
+  "adaptive": {
+    "meta_state_registry": "/Users/tamld/Documents/MCP-Server/memory/core/reflection/meta_state_registry.json",
+    "adaptive_state": "/Users/tamld/Documents/MCP-Server/memory/projects/cmdToolForHelpdesk/reflection/adaptive_state.json",
+    "conflict_log": "/Users/tamld/Documents/MCP-Server/memory/projects/cmdToolForHelpdesk/reflection/conflict_resolution.jsonl",
+    "decision_rules": {
+      "use_core_if_delta_lt": 0.2,
+      "use_adaptive_if_better_by": 0.3,
+      "fallback_to_core_when_adaptive_worse": true,
+      "escalate_on_major_conflict": true
+    }
+  }
+}

--- a/.agent/workflows/release.json
+++ b/.agent/workflows/release.json
@@ -1,0 +1,16 @@
+{
+  "name": "release_cut",
+  "goal": "Produce a tagged release with verified scripts",
+  "prereq": [
+    "All milestone items closed or deferred",
+    "Sanity tests pass"
+  ],
+  "steps": [
+    "Bump version and date in Helpdesk-Tools.cmd header",
+    "Smoke-test menus: install, utilities, package management",
+    "Verify winget/choco checks, no placeholder holds",
+    "Update docs/roadmap.md and changelog section",
+    "Post-deployment learning: append lesson to project learning/lessons.jsonl and update learning/summary.json per schema",
+    "Tag release and attach artifacts if needed"
+  ]
+}

--- a/.agent/workflows/triage.json
+++ b/.agent/workflows/triage.json
@@ -1,0 +1,12 @@
+{
+  "name": "issue_triage",
+  "goal": "Quickly classify and prioritize new issues/PRs",
+  "steps": [
+    "Reproduce or locate relevant labels/lines",
+    "Assign priority (p0/p1/p2) and component",
+    "Link to related backlog items or create new",
+    "Define acceptance criteria",
+    "Reflection gate: confirm no context conflicts; if uncertain, ask user",
+    "Queue into nearest milestone in roadmap"
+  ]
+}

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -1,0 +1,48 @@
+name: Windows CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  static:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Static checks
+        shell: pwsh
+        run: |
+          ./cmdToolForHelpdesk/scripts/test.ps1 -Stage static -Offline
+
+  smoke:
+    runs-on: windows-latest
+    needs: static
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup shims
+        shell: pwsh
+        run: |
+          ./cmdToolForHelpdesk/scripts/setup-shims.ps1
+      - name: Smoke test (dry-run)
+        shell: pwsh
+        env:
+          SAFE_MODE: '1'
+          DRY_RUN: '1'
+          CI: '1'
+        run: |
+          ./cmdToolForHelpdesk/scripts/test.ps1 -Stage smoke -Offline
+
+  unattend:
+    runs-on: windows-latest
+    needs: static
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Validate unattend XML
+        shell: pwsh
+        run: |
+          ./cmdToolForHelpdesk/scripts/test.ps1 -Stage unattend -Offline

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -15,7 +15,11 @@ jobs:
       - name: Static checks
         shell: pwsh
         run: |
-          ./cmdToolForHelpdesk/scripts/test.ps1 -Stage static -Offline
+          Set-ExecutionPolicy Bypass -Scope Process -Force
+          $ws = "$env:GITHUB_WORKSPACE"
+          $script = Join-Path $ws 'scripts\test.ps1'
+          if (!(Test-Path $script)) { Write-Error "Missing script: $script"; exit 1 }
+          & $script -Stage static -Offline
 
   smoke:
     runs-on: windows-latest
@@ -26,7 +30,11 @@ jobs:
       - name: Setup shims
         shell: pwsh
         run: |
-          ./cmdToolForHelpdesk/scripts/setup-shims.ps1
+          Set-ExecutionPolicy Bypass -Scope Process -Force
+          $ws = "$env:GITHUB_WORKSPACE"
+          $shim = Join-Path $ws 'scripts\setup-shims.ps1'
+          if (!(Test-Path $shim)) { Write-Error "Missing script: $shim"; exit 1 }
+          & $shim
       - name: Smoke test (dry-run)
         shell: pwsh
         env:
@@ -34,7 +42,11 @@ jobs:
           DRY_RUN: '1'
           CI: '1'
         run: |
-          ./cmdToolForHelpdesk/scripts/test.ps1 -Stage smoke -Offline
+          Set-ExecutionPolicy Bypass -Scope Process -Force
+          $ws = "$env:GITHUB_WORKSPACE"
+          $script = Join-Path $ws 'scripts\test.ps1'
+          if (!(Test-Path $script)) { Write-Error "Missing script: $script"; exit 1 }
+          & $script -Stage smoke -Offline
 
   unattend:
     runs-on: windows-latest
@@ -45,4 +57,8 @@ jobs:
       - name: Validate unattend XML
         shell: pwsh
         run: |
-          ./cmdToolForHelpdesk/scripts/test.ps1 -Stage unattend -Offline
+          Set-ExecutionPolicy Bypass -Scope Process -Force
+          $ws = "$env:GITHUB_WORKSPACE"
+          $script = Join-Path $ws 'scripts\test.ps1'
+          if (!(Test-Path $script)) { Write-Error "Missing script: $script"; exit 1 }
+          & $script -Stage unattend -Offline

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,50 @@
+# Agent Coaching Playbook (Root)
+
+Purpose
+- Single, reusable guide for agents across repos; points to repo‑specific assets in `.agent/`.
+
+Quickstart
+- Read `.agent/policies.json`, `.agent/backlog.json`, `.agent/roadmap.json`.
+- Before any edits: write a short plan and preamble; make minimal, reversible changes.
+- Use `rg` for search, chunk reads ≤250 lines, and `apply_patch` for edits.
+
+Operating Rules
+- Scope: change only what the task requires; avoid unrelated fixes.
+- Safety: no secrets in repo; pin versions and verify downloads.
+- Compatibility: support Win10 19041+ and Win11; guard features by build/registry checks.
+- Network: prefer official sources; justify any `--ignore-checksums`.
+
+Non‑Overridable Law (Highest Priority)
+- Before significant actions or recommendations, reflect: "Am I going beyond necessary information or current context (including MCP memory)? Is there any conflict with the current task?" If yes, pause and ask the user to confirm before proceeding. This rule cannot be replaced or overridden.
+
+Planning & Execution
+- Plans: concise steps (5–7 words), exactly one `in_progress`.
+- Preambles: 1–2 sentences before tool calls to explain what’s next.
+- Validation: test smallest surface first, then broader; document manual steps if needed.
+
+Tools & Conventions
+- Search: `rg`, `rg --files -uu` for speed.
+- Edits: `apply_patch` only; do not run external editors.
+- File reads: ≤250 lines per chunk to avoid truncation.
+- Messages: concise, actionable; use bullets and backticks for paths/commands.
+
+Documentation Preference
+- For complex flows, prefer Workflow diagrams using Mermaid in human‑readable docs (README/specs). Keep the diagram as the single source of truth for the flow and reference it from text.
+
+Assets Convention
+- Images under `pictures/`; docs under `docs/`. Keep references relative and include alt text for accessibility.
+
+Repo Structure Pointers
+- Policies: `.agent/policies.json`
+- Goals/Backlog/Roadmap: `.agent/goals.json`, `.agent/backlog.json`, `.agent/roadmap.json`
+- Workflows: `.agent/workflows/*.json`
+- Session state: `.agent/state/checklist.json`, `.agent/state/progress.json`
+- Human docs: `docs/` (spec, roadmap, RPM)
+
+MCP Memory Sync
+- Long‑term: store principles/pointers in `.../memory/projects/<name>/ltm.json`.
+- Short‑term: current focus and next actions in `.../stm.json`.
+- Project index: keep pointers and next_action in `.../index.json`.
+
+Done Criteria
+- Acceptance criteria in backlog items met; no placeholders left in the touched area; validation passes without regressions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# Contributing Guidelines
+
+GitHub Workflow
+- Large changes: open a Pull Request (PR) for review before merging.
+- Small changes (docs tweaks, minor fixes): commit directly to main if low risk.
+- Major bugs/refactors or release planning: open an Issue first and track progress there.
+- Versioning: bump SemVer (vMAJOR.MINOR.PATCH) for big updates; include date in script header.
+
+PR Expectations
+- Describe scope, risks, and test/validation steps.
+- Link related Issues and acceptance criteria.
+- Keep changes minimal and reversible.
+
+Branching
+- Use short, descriptive branches: `feat/...`, `fix/...`, `docs/...`, `refactor/...`.
+
+Code of Conduct
+- Be concise, respectful, and review constructively.
+

--- a/Helpdesk-Tools.cmd
+++ b/Helpdesk-Tools.cmd
@@ -49,7 +49,7 @@ echo    [7] Exit                                       : Press 7
 echo    ========================================================
 Choice /N /C 1234567 /M " Press your choice :"
 ::if %ERRORLEVEL% == 8 call :checkCompatibility & goto main
-if %ERRORLEVEL% == 7 call :clean && goto exit
+if %ERRORLEVEL% == 7 call :clean && goto end
 if %ERRORLEVEL% == 6 call :updateCMD & goto main
 if %ERRORLEVEL% == 5 goto packageManagementMenu
 if %ERRORLEVEL% == 4 goto utilities

--- a/Helpdesk-Tools.cmd
+++ b/Helpdesk-Tools.cmd
@@ -597,22 +597,18 @@ Title Active Licenses Menu
 cls
 echo.
 echo        ========================================================
-echo        [1] Online                                     : Press 1
-echo        [2] By Phone                                   : Press 2
-echo        [3] Check Licenses                             : Press 3
-echo        [4] Backup Licenses                            : Press 4
-echo        [5] Restore License                            : Press 5
+echo        [1] Online (Coming soon)                       : Press 1
+echo        [2] By Phone (Coming soon)                     : Press 2
+echo        [3] Check Licenses (Coming soon)               : Press 3
+echo        [4] Backup Licenses (Coming soon)              : Press 4
+echo        [5] Restore License (Coming soon)              : Press 5
 echo        [6] MAS (Microsoft Activation Scripts)         : Press 6
 echo        [7] Back to Main Menu                          : Press 7
 echo        ========================================================
 Choice /N /C 1234567 /M " Press your choice : "
 if %ERRORLEVEL% == 7 goto :main
 if %ERRORLEVEL% == 6 goto :MAS
-if %ERRORLEVEL% == 5 goto :restoreLicenses
-if %ERRORLEVEL% == 4 goto :backupLicenses
-if %ERRORLEVEL% == 3 goto :checkLicense
-if %ERRORLEVEL% == 2 goto :activeByPhone
-if %ERRORLEVEL% == 1 goto :activeOnline
+if %ERRORLEVEL% LEQ 5 (echo This function is not available yet. & ping -n 2 localhost >nul & goto :activeLicenses)
 endlocal
 
 REM End of Active Licenses Menu
@@ -711,6 +707,10 @@ goto :EOF
 
 :debloat
 TITLE Windows Debloat
+if "%DRY_RUN%"=="1" (
+echo [DRY_RUN] Skipping debloat operations
+goto :EOF
+)
 echo Remove Unused Packages, Bloatwares
 echo Winget uninstall debloat packages
 call :winget_debloat
@@ -789,6 +789,10 @@ goto :utilities
 Title Install Support Assistant
 call :checkCompatibility
 cls
+if "%DRY_RUN%"=="1" (
+echo [DRY_RUN] Skipping Support Assistant installation
+goto :eof
+)
 echo Installing Support Assistant
 ping -n 3 localhost 1>NUL
 setlocal
@@ -851,6 +855,10 @@ REM This function will use Windows Disk Cleanup to remove unnecessary files
 :cleanUpSystem
 Title Clean Up System
 cls
+if "%DRY_RUN%"=="1" (
+echo [DRY_RUN] Skipping system cleanup (registry/cleanmgr)
+goto :utilities
+)
 echo This will cleanup temp folder and add preset for Windows Cleanup Utilities
 echo You can execute the command cleanmgr /sagerun:1 afterward
 call :clean > NUL
@@ -976,11 +984,11 @@ goto :EOF
 :createShortcut
 cls
 @echo off
-COPY /Y "%startProgram%\*.lnk" "%AllUsersProfile%\Desktop"
-COPY /Y "%startProgram%\BCUninstaller\BCUninstaller.lnk" "%AllUsersProfile%\Desktop"
-COPY /Y "%startProgram%\Foxit PDF Reader\Foxit PDF Reader.lnk" "%AllUsersProfile%\Desktop"
-COPY /Y "%startProgram%\Slack Technologies Inc\*.lnk" "%AllUsersProfile%\Desktop"
-COPY /Y "%startProgram%\UltraViewer\*.lnk" "%AllUsersProfile%\Desktop"
+if exist "%startProgram%\*.lnk" COPY /Y "%startProgram%\*.lnk" "%AllUsersProfile%\Desktop"
+if exist "%startProgram%\BCUninstaller\BCUninstaller.lnk" COPY /Y "%startProgram%\BCUninstaller\BCUninstaller.lnk" "%AllUsersProfile%\Desktop"
+if exist "%startProgram%\Foxit PDF Reader\Foxit PDF Reader.lnk" COPY /Y "%startProgram%\Foxit PDF Reader\Foxit PDF Reader.lnk" "%AllUsersProfile%\Desktop"
+if exist "%startProgram%\Slack Technologies Inc\*.lnk" COPY /Y "%startProgram%\Slack Technologies Inc\*.lnk" "%AllUsersProfile%\Desktop"
+if exist "%startProgram%\UltraViewer\*.lnk" COPY /Y "%startProgram%\UltraViewer\*.lnk" "%AllUsersProfile%\Desktop"
 goto :eof
 
 :packageManagementMenu
@@ -1535,6 +1543,10 @@ Title Add Winget Shedule Upgrade
 REM Create schedule task auto upgrade all software with hidden option
 REM Schedule task run onlogon with current user running
 REM schtasks /create /tn "Winget Upgrade" /tr "winget.exe upgrade -h --all" /sc onlogon
+if "%DRY_RUN%"=="1" (
+echo [DRY_RUN] Skipping schedule task creation
+goto :eof
+)
 schtasks /create /tn "Winget Upgrade" /tr "winget upgrade -h --all" /sc onlogon /ru %username% /f
 goto :eof
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,32 @@
+This folder contains human-readable documentation for cmdToolForHelpdesk.
+
+Contents
+- spec-cmdtool.md: Feature spec, structure, and behavior.
+- roadmap.md: Narrative milestones and priorities.
+- rpm.md: Roles, Process, Metrics (how we operate).
+- backlog.md: A readable mirror of .agent/backlog.json (high-level).
+
+Visualization
+- Prefer Mermaid workflow diagrams for complex procedures and multi-step flows. Keep diagrams canonical and reference them within the surrounding text.
+
+Markdown Conventions (icons, images, matrices, anchors)
+- Icons/Badges: use emojis (e.g., 🚀) and Shields badges. Example: `![Status](https://img.shields.io/badge/status-active-brightgreen)`.
+- Images: store under `pictures/` or `docs/img/` and reference with relative paths. Always include alt text. For sizing, use HTML if needed: `<img src="pictures/1.png" alt="Main menu" width="480" />`.
+- Tables/Matrices: prefer GitHub Markdown tables to present comparisons or matrices.
+  Example:
+  
+  | Feature | Windows 10 | Windows 11 |
+  |:--|:--:|:--:|
+  | Winget | ✅ | ✅ |
+  | ODT    | ✅ | ✅ |
+
+- Custom Anchors for Index: headings auto-generate anchors on GitHub (link with `[text](#heading-text)`). For custom ids, add an HTML anchor before a section: `<a id="troubleshooting"></a>` then link with `[Troubleshooting](#troubleshooting)`.
+- Index/TOC: add a short manual TOC at the top linking to key sections; keep 5–8 items for scanability. Tools like Doctoc are optional; prefer manual for control.
+- Callouts/Details: use blockquotes for callouts (`> Note:`) and `<details><summary>...</summary>...</details>` for collapsible sections when content is long.
+
+Assets Layout
+- Images: place under `pictures/` at repo root; reference with relative paths in docs (e.g., `![Main menu](pictures/1.png)`).
+- Documents: place human‑readable specs and guides under `docs/`; keep agent‑facing JSON/TXT under `.agent/`.
+- Keep assets lightweight; prefer linking to large binaries rather than committing them.
+
+Note: Agents should use the compact JSON sources in .agent/ and refer here for details and rationale.

--- a/docs/adr/0001-language-and-shell.md
+++ b/docs/adr/0001-language-and-shell.md
@@ -1,0 +1,16 @@
+ADR-0001: Language and Shell
+
+Context
+- Targets Windows 10+/11. Needs ubiquitous runtime and simple distribution.
+
+Decision
+- Use Batch (`.cmd`) for menus/launchers and simple orchestration.
+- Use PowerShell for complex logic (downloads, zip extraction, registry ops).
+
+Status
+- Accepted.
+
+Consequences
+- Keep batch labels small; delegate to PowerShell when logic grows.
+- Ensure PowerShell execution policy handled where needed.
+

--- a/docs/adr/0002-package-managers.md
+++ b/docs/adr/0002-package-managers.md
@@ -1,0 +1,14 @@
+ADR-0002: Package Managers (winget vs choco)
+
+Context
+- Need reliable software installation on Windows.
+
+Decision
+- Prefer `winget` when present (Windows 10 19041+), fallback to `choco`.
+
+Status
+- Accepted.
+
+Consequences
+- Implement detection and version checks for winget; ensure choco path and self-heal logic.
+

--- a/docs/adr/0003-download-security.md
+++ b/docs/adr/0003-download-security.md
@@ -1,0 +1,15 @@
+ADR-0003: Download Security
+
+Context
+- External downloads (ODT, Office Tool Plus, vendor tools) can change and pose risk.
+
+Decision
+- Pin versions and verify checksums/signatures when feasible.
+- Prefer official sources and TLS.
+
+Status
+- Accepted.
+
+Consequences
+- Maintain version pins and hashes; update via controlled process.
+

--- a/docs/adr/0004-versioning-and-release.md
+++ b/docs/adr/0004-versioning-and-release.md
@@ -1,0 +1,15 @@
+ADR-0004: Versioning and Release
+
+Context
+- Need predictable releases and rollback.
+
+Decision
+- Use SemVer style `vMAJOR.MINOR.PATCH` + date in header.
+- Maintain changelog in docs/roadmap.md and SOP in .agent/workflows/release.json.
+
+Status
+- Accepted.
+
+Consequences
+- Tag releases in VCS; smoke test post-cut; document rollback.
+

--- a/docs/adr/index.json
+++ b/docs/adr/index.json
@@ -1,0 +1,8 @@
+{
+  "adrs": [
+    {"id": "0001", "title": "Language and Shell", "path": "docs/adr/0001-language-and-shell.md"},
+    {"id": "0002", "title": "Package Managers", "path": "docs/adr/0002-package-managers.md"},
+    {"id": "0003", "title": "Download Security", "path": "docs/adr/0003-download-security.md"},
+    {"id": "0004", "title": "Versioning and Release", "path": "docs/adr/0004-versioning-and-release.md"}
+  ]
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,23 @@
+Architecture (Project‑Specific)
+
+Runtime
+- Windows 10 (19041+) and Windows 11.
+- Batch (`.cmd`) as primary launcher/menu; PowerShell for complex logic and zip extraction.
+
+Structure
+- `Helpdesk-Tools.cmd`: main entry; calls modular labels for features.
+- `packages/`: vendor scripts and resources (debloat, ODT, etc.).
+- `scripts/`: virtualization helpers (sandbox, hyper-v, vbox).
+- `.agent/`: agent configs, backlog, workflows, decisions.
+
+Decisions
+- Prefer `winget` if available; fallback to `choco` (ADR‑0002).
+- Pin downloads and verify where feasible (ADR‑0003).
+- Consolidate duplicate helpers; single source of truth (policy).
+
+Observability
+- Clear echo/exit code paths; avoid noisy output.
+
+Security
+- Elevate only when required; no secrets in repo; verify sources.
+

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,0 +1,15 @@
+Backlog (human-readable snapshot)
+
+- A-001: Fix Windows 11 detection logic in :settingWindows (p0)
+- A-002: Consolidate duplicate helpers (p0)
+- A-003: Pin and verify Office/OTP/ODT downloads (p0)
+- A-004: Implement Active Licenses actions (p1)
+- A-005: Implement AIO System-Network/Helpdesk or hide (p1)
+- A-006: Harden Support Assistant installs (p1)
+- A-007: Guard createShortcut with existence checks (p2)
+- A-008: Fix run-in-sandbox mapped folder copy/launcher (p1)
+- A-009: Implement basic actions in refactor.cmd menus (p2)
+- A-010: Fallback/no-network handling for GitHub API (p2)
+
+Source of truth: .agent/backlog.json
+

--- a/docs/coding-standards.md
+++ b/docs/coding-standards.md
@@ -1,0 +1,30 @@
+# Coding Standards (Batch/Powershell)
+
+Comments
+- Use English for all code comments and docstrings.
+- Prefer `::` over `REM` for comments in batch files.
+- Keep explanations short, focused, and near the logic they describe.
+
+Labels (Batch)
+- Naming: lowerCamelCase without hyphens. Avoid spaces and special characters.
+- Verbs first: `installAio`, `installAioO2019`, `checkCompatibility`, `packageManagementMenu`.
+- Menu labels end with `Menu`; actions start with a verb; helpers use clear nouns.
+- Avoid duplicate labels; group logically by prefix (e.g., `install*`, `package*`, `office*`).
+
+Variables
+- Environment variables: UPPER_CASE where practical; local script vars: lower_snake_case or descriptive names.
+- Be consistent within a file; avoid one-letter names except in loops.
+
+Structure
+- One purpose per label/function; keep labels small and composable.
+- Centralize shared helpers (installSoft_ByWinget/Choco, extractZip, downloadFile) to a single definition.
+- Guard OS/version-specific logic (Windows 10/11) with explicit checks.
+
+PowerShell
+- Use PowerShell for complex logic (downloads, archive, registry); batch for menus/launchers.
+- Prefer explicit error handling and clear exit codes.
+
+Examples
+- Label: `:installAioO2019` (verb + target + version)
+- Comment: `:: Extract OTP to temp and run deployment`
+

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,14 @@
+Milestones
+
+- 0.7.0 — Stabilize core & security hardening
+  - Fix Win11 detection, consolidate helpers, pin/check downloads, offline-safe checks
+
+- 0.8.0 — Feature completeness for Licenses & AIO
+  - Implement Activation flows and AIO variants
+  - Fix sandbox runner and shortcut guards
+
+- 0.9.0 — Refactor & dev ergonomics
+  - Implement basic refactor.cmd actions, reduce duplication
+
+See .agent/roadmap.json for machine-readable plan.
+

--- a/docs/rpm.md
+++ b/docs/rpm.md
@@ -1,0 +1,14 @@
+Roles
+- Maintainer: reviews changes, approves releases, manages external dependencies.
+- Engineering Agent: implements scoped changes per backlog and policies.
+
+Process
+- Triage issues → define acceptance criteria → implement minimal change → validate → document in docs/ if behavior changes.
+- Prefer additive changes and refactors over broad rewrites.
+
+Metrics
+- Placeholder count trends to zero.
+- Install/update success rate.
+- Duplicate helper count decreases.
+- Time-to-triage and time-to-release.
+

--- a/docs/spec-cmdtool.md
+++ b/docs/spec-cmdtool.md
@@ -1,0 +1,31 @@
+Overview
+- Helpdesk-Tools.cmd provides menu-driven automation for Windows helpdesk tasks: install software, manage Office, activation helpers, utilities, and package management via winget/chocolatey.
+
+Structure
+- Main menu: Install AIO, Windows/Office utilities, Activation, Utilities, Package Management, Self-update.
+- Installers: winget/choco helpers, grouped app lists for End-users, Remote Support, Network tools, Chat apps.
+- Office: Office Tool Plus deploy flow, ODT for O365, conversion and uninstall helpers.
+- Utilities: performance plan, hostname change, cleanup, debloat, vendor Support Assistants, winutil integration.
+- Common helpers: version checks, download/extract, schedule tasks, kill tasks, cleanup temp.
+
+Key Design Points
+- Run as admin with UAC elevation.
+- Prefer winget when available, fallback to choco.
+- Network calls should be version-pinned when feasible; checksums preferred.
+- Windows 10/11 detection must rely on build or registry, not product name substring.
+- Avoid duplicate function definitions; keep single source of truth for helpers.
+
+Constraints
+- Windows 10 (19041+) and Windows 11.
+- No secrets in repo; no license keys stored.
+
+Known Gaps (to implement)
+- Active Licenses submenus call placeholders.
+- AIO System-Network/Helpdesk variants incomplete.
+- Some downloads use unpinned URLs and ignore checksums.
+- Duplicate helpers exist in multiple sections.
+
+References
+- .agent/backlog.json for actionable tasks.
+- .agent/policies.json for coding, security, and planning rules.
+

--- a/scripts/checksums.json
+++ b/scripts/checksums.json
@@ -1,0 +1,14 @@
+{
+  "artifacts": [
+    {
+      "name": "officedeploymenttool.exe",
+      "path": "packages/officedeploymenttool.exe",
+      "sha256": ""
+    },
+    {
+      "name": "Licenses.zip",
+      "path": "packages/Licenses.zip",
+      "sha256": ""
+    }
+  ]
+}

--- a/scripts/setup-shims.ps1
+++ b/scripts/setup-shims.ps1
@@ -1,0 +1,15 @@
+$ErrorActionPreference = 'Stop'
+$shims = Join-Path $PSScriptRoot 'shims'
+New-Item -ItemType Directory -Force -Path $shims | Out-Null
+
+@('winget','choco','curl','aria2c') | ForEach-Object {
+  $p = Join-Path $shims ("{0}.cmd" -f $_)
+  @"
+@echo off
+echo [SHIM] %~n0 %*
+exit /b 0
+"@ | Set-Content -Path $p -Encoding ASCII
+}
+
+$env:PATH = "$shims;$($env:PATH)"
+Write-Host "Shims ready at $shims and PATH updated for this session"

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -51,7 +51,9 @@ function Test-Smoke {
   $env:SAFE_MODE = '1'; $env:DRY_RUN = '1'; $env:CI = '1'
   $psi = New-Object System.Diagnostics.ProcessStartInfo
   $psi.FileName = 'cmd.exe'
-  $psi.Arguments = "/c echo 7| \"$cmdFile\""
+  # Build arguments safely with quoted path
+  $quoted = '"' + $cmdFile + '"'
+  $psi.Arguments = "/c echo 7| $quoted"
   $psi.RedirectStandardOutput = $true
   $psi.RedirectStandardError = $true
   $psi.UseShellExecute = $false

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -1,0 +1,95 @@
+param(
+  [ValidateSet('static','smoke','unattend','all')]
+  [string]$Stage = 'all',
+  [switch]$Offline
+)
+
+$ErrorActionPreference = 'Stop'
+function Write-Ok($m){ Write-Host "[OK] $m" -ForegroundColor Green }
+function Write-Warn($m){ Write-Host "[WARN] $m" -ForegroundColor Yellow }
+function Write-Fail($m){ Write-Host "[FAIL] $m" -ForegroundColor Red; exit 1 }
+
+$repo = Split-Path -Parent $PSScriptRoot
+$cmdFile = Join-Path $repo 'Helpdesk-Tools.cmd'
+$unattend1 = Join-Path $repo 'packages/autounattend.xml'
+$unattend2 = Join-Path $repo 'packages/autounattend_wipe-all.xml'
+
+if(-not (Test-Path $cmdFile)){ Write-Fail "Missing $cmdFile" }
+
+function Test-Static {
+  Write-Host "== Static checks =="
+  $content = Get-Content -Raw -Path $cmdFile
+
+  # Collect labels
+  $labels = Select-String -InputObject $content -Pattern '^[ \t]*:([A-Za-z0-9_\-]+)' -AllMatches -Multiline | ForEach-Object { $_.Matches } | ForEach-Object { $_.Groups[1].Value }
+  $dup = $labels | Group-Object | Where-Object { $_.Count -gt 1 }
+  if($dup){ $dup | ForEach-Object { Write-Warn ("Duplicate label: {0} x{1}" -f $_.Name, $_.Count) } }
+  else { Write-Ok "No duplicate labels" }
+
+  # Collect gotos/calls
+  $calls = @()
+  $calls += (Select-String -InputObject $content -Pattern '(?mi)\bcall\s*:\s*([A-Za-z0-9_\-]+)' | ForEach-Object { $_.Matches.Groups[1].Value })
+  $calls += (Select-String -InputObject $content -Pattern '(?mi)\bgoto\s*:?(\S+)' | ForEach-Object { $_.Matches.Groups[1].Value })
+  $labelsSet = [Collections.Generic.HashSet[string]]::new()
+  $null = $labels | ForEach-Object { [void]$labelsSet.Add($_) }
+  $unresolved = $calls | Where-Object { -not $labelsSet.Contains($_) } | Select-Object -Unique
+  if($unresolved){ $unresolved | ForEach-Object { Write-Warn "Unresolved target: $_" } } else { Write-Ok "All goto/call targets resolvable" }
+
+  # Banned/risky patterns (warn only for initial setup)
+  if($content -match '(?mi)call\s*:\s*hold'){ Write-Warn "Found placeholder calls to :hold" } else { Write-Ok "No :hold placeholders referenced" }
+  if($content -match '--ignore-checksums'){ Write-Warn "Found --ignore-checksums (consider removing or justifying)" } else { Write-Ok "No --ignore-checksums" }
+  if($content -match '(?mi)wmic\s+os\s+get\s+name'){ Write-Warn "WMIC OS name detection present; prefer build/registry" } else { Write-Ok "No WMIC OS name detection found" }
+
+  # setlocal presence
+  if($content -match '(?mi)^\s*setlocal\b'){ Write-Ok "setlocal found" } else { Write-Warn "setlocal not found" }
+}
+
+function Test-Smoke {
+  Write-Host "== Smoke test (dry-run) =="
+  # Setup shims
+  & (Join-Path $PSScriptRoot 'setup-shims.ps1') | Out-Null
+  $env:SAFE_MODE = '1'; $env:DRY_RUN = '1'; $env:CI = '1'
+  $psi = New-Object System.Diagnostics.ProcessStartInfo
+  $psi.FileName = 'cmd.exe'
+  $psi.Arguments = "/c echo 7| \"$cmdFile\""
+  $psi.RedirectStandardOutput = $true
+  $psi.RedirectStandardError = $true
+  $psi.UseShellExecute = $false
+  $p = [System.Diagnostics.Process]::Start($psi)
+  $out = $p.StandardOutput.ReadToEnd()
+  $err = $p.StandardError.ReadToEnd()
+  $p.WaitForExit()
+  if($p.ExitCode -ne 0){ Write-Fail "Helpdesk-Tools exited with $($p.ExitCode): $err" }
+  if($out -match '\[1\] Install All In One Online' -or $out -match 'Main Menu'){ Write-Ok "Main menu rendered" } else { Write-Warn "Menu banner not detected; review output" }
+}
+
+function Test-Unattend {
+  Write-Host "== Unattend XML validation =="
+  foreach($f in @($unattend1,$unattend2)){
+    if(Test-Path $f){
+      try { [xml]$x = Get-Content -Raw -Path $f } catch { Write-Fail "XML not well-formed: $f" }
+      Write-Ok "XML well-formed: $f"
+      # Check key nodes
+      $ns = @{ wcm = 'http://schemas.microsoft.com/WMIConfig/2002/State' }
+      if($x.unattend.settings.component | Where-Object { $_.name -like '*Shell-Setup*' }){ Write-Ok "Shell-Setup component present" } else { Write-Warn "Shell-Setup missing" }
+      # Check passwords encoded
+      if($x.unattend.settings.component.UserAccounts.AdministratorPassword.Value){
+        $plain = $x.unattend.settings.component.UserAccounts.AdministratorPassword.PlainText
+        if($plain -eq 'false'){ Write-Ok "Administrator password not plaintext" } else { Write-Warn "Administrator password marked plaintext" }
+      }
+      # Check FirstLogonCommands exists
+      if($x.unattend.settings.component.FirstLogonCommands){ Write-Ok "FirstLogonCommands present" } else { Write-Warn "FirstLogonCommands missing" }
+    } else {
+      Write-Warn "Unattend file not found: $f"
+    }
+  }
+}
+
+switch($Stage){
+  'static' { Test-Static }
+  'smoke' { Test-Smoke }
+  'unattend' { Test-Unattend }
+  'all' { Test-Static; Test-Smoke; Test-Unattend }
+}
+
+Write-Host "== Done =="


### PR DESCRIPTION
Summary\n- Add Windows CI pipeline (.github/workflows/windows-ci.yml) with static/smoke/unattend jobs.\n- Add test harness: scripts/test.ps1 (static label/goto checks, smoke dry-run with shims, unattend XML lint) and scripts/setup-shims.ps1.\n- Add scripts/checksums.json manifest (placeholders) for future pinning.\n- Add .agent policies/workflows/state + docs (ADR/architecture/coding-standards/repo guidelines).\n- Add safety guards in Helpdesk-Tools.cmd: DRY_RUN for debloat/cleanup/schedule/support assistant; hardened createShortcut; annotate inactive license menu items.\n\nSafety\n- All CI tests run offline; destructive paths are guarded by DRY_RUN/SAFE_MODE and PATH shims.\n\nValidation\n- Local: scripts/test.ps1 -Stage static|smoke|unattend.\n- CI: runs on PR to main (Windows runner).\n\nNotes\n- Follow-up PRs will cover Win10/11 detector and helper deduplication as separate, small changes.]}